### PR TITLE
Fix b:strip_trailing_whitespace_enabled behavior.

### DIFF
--- a/plugin/strip_trailing_whitespace.vim
+++ b/plugin/strip_trailing_whitespace.vim
@@ -192,6 +192,7 @@ function StripTrailingWhitespaceListener(bufnr, start, end, added, changes) abor
 endfunction
 
 function s:OnBufEnter() abort
+	if !get(b:, 'strip_trailing_whitespace_enabled', 1) | return | endif
 	if exists('b:stw_root') | return | endif
 	let [b:stw_root, b:stw_count] = [v:null, 0]
 	if has('nvim')


### PR DESCRIPTION
When `let b:strip_trailing_whitespace_enabled = 0`, we should not add listener to the buffer.