### PR TITLE
Ignore generated doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When using the plugin with Plugged and as a submodule this file gets generated which should be ignored.